### PR TITLE
Fixes #168: Pin shell to /bin/sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV \
 
 COPY --from=builder --chown=node:node /directus/dist .
 
-SHELL ["/bin/bash", "-c"]
+SHELL ["/bin/sh", "-c"]
 CMD : \
 	&& node /directus/cli.js bootstrap \
 	&& node /directus/cli.js start \


### PR DESCRIPTION
This pins the shell to `/bin/sh`

Embarrassingly I have to open this again as `/bin/bash` is not available in the underlying container. Since automation did not catch it: This time "manually verified"™

- Container build using modidied `Dockerfile`
- Container run using Docker CE v29 using `docker compose`.

### Result
Container started.

## Change description

Pin Dockerfile shell to `/bin/sh` as /bin/bash is not vailable in `busybox` based container

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix #169 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Network

- [ ] Changes to network configurations have been reviewed
- [ ] Any newly exposed public endpoints or data have gone through security review

### Code review

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] reviewers assigned 
- [ ] Pull request linked to task tracker where applicable

