### PR TITLE
Fix OpenID login failure caused by dynamic redirect_uri breaking strict providers like Azure AD

### DIFF
--- a/api/src/auth/drivers/openid.test.ts
+++ b/api/src/auth/drivers/openid.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 
 const { mockAuthorizationUrl, mockCallback } = vi.hoisted(() => {
 	const mockAuthorizationUrl = vi.fn().mockReturnValue('https://provider.example.com/auth?state=mock-challenge');
+
 	const mockCallback = vi.fn().mockResolvedValue({
 		access_token: 'mock-access-token',
 		refresh_token: 'mock-refresh-token',
@@ -286,6 +287,7 @@ describe('OpenIDAuthDriver', () => {
 
 			expect(tokenSet).toHaveProperty('access_token', 'mock-access-token');
 			expect(userInfo).toHaveProperty('email', 'user@example.com');
+
 			expect(userPayload).toMatchObject({
 				provider: 'test-provider',
 				email: 'user@example.com',

--- a/api/src/auth/drivers/openid.test.ts
+++ b/api/src/auth/drivers/openid.test.ts
@@ -1,0 +1,329 @@
+import type { SchemaOverview } from '@wbce-d9/types';
+import type { Knex } from 'knex';
+import knex from 'knex';
+import { MockClient } from 'knex-mock-client';
+import type { MockedFunction } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAuthorizationUrl, mockCallback } = vi.hoisted(() => {
+	const mockAuthorizationUrl = vi.fn().mockReturnValue('https://provider.example.com/auth?state=mock-challenge');
+	const mockCallback = vi.fn().mockResolvedValue({
+		access_token: 'mock-access-token',
+		refresh_token: 'mock-refresh-token',
+		claims: () => ({
+			sub: 'user-123',
+			email: 'user@example.com',
+			given_name: 'Test',
+			family_name: 'User',
+		}),
+	});
+
+	return { mockAuthorizationUrl, mockCallback };
+});
+
+vi.mock('../../database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+vi.mock('../../env', () => {
+	const MOCK_ENV: Record<string, any> = {
+		PUBLIC_URL: 'http://localhost:8055',
+		SECRET: 'test-secret',
+		EXTENSIONS_PATH: '/tmp/extensions',
+		STORAGE_LOCATIONS: '',
+		DB_CLIENT: 'sqlite3',
+		RATE_LIMITER_ENABLED: false,
+		CACHE_ENABLED: false,
+		EMAIL_TRANSPORT: 'sendmail',
+		ACCESS_TOKEN_TTL: '15m',
+		REFRESH_TOKEN_TTL: '7d',
+		REFRESH_TOKEN_COOKIE_NAME: 'directus_refresh_token',
+		ACCESS_TOKEN_COOKIE_NAME: 'directus_access_token',
+		AUTH_PROVIDERS: '',
+	};
+
+	return {
+		default: MOCK_ENV,
+		getEnv: vi.fn().mockImplementation(() => MOCK_ENV),
+	};
+});
+
+vi.mock('../../logger', () => ({
+	default: {
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		trace: vi.fn(),
+		fatal: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
+vi.mock('../../emitter', () => ({
+	default: {
+		emitFilter: vi.fn().mockImplementation((_: any, payload: any) => Promise.resolve(payload)),
+		emitAction: vi.fn(),
+	},
+}));
+
+vi.mock('../../cache', () => ({
+	getCache: vi.fn().mockReturnValue({
+		cache: { clear: vi.fn() },
+		systemCache: { clear: vi.fn() },
+	}),
+}));
+
+vi.mock('../../messenger', () => ({
+	getMessenger: vi.fn().mockReturnValue({
+		publish: vi.fn(),
+		subscribe: vi.fn(),
+	}),
+}));
+
+vi.mock('../../rate-limiter', () => ({
+	default: vi.fn(),
+	createRateLimiter: vi.fn(),
+}));
+
+vi.mock('../../services/mail/index', () => {
+	const MailService = vi.fn();
+	MailService.prototype.send = vi.fn();
+	return { MailService };
+});
+
+vi.mock('../../auth', () => ({
+	getAuthProvider: vi.fn(),
+}));
+
+vi.mock('../../utils/get-config-from-env', () => ({
+	getConfigFromEnv: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('openid-client', () => {
+	// Use a real class so the constructor works with `new issuer.Client(...)`.
+	// vi.fn().mockImplementation() fails as a constructor in vitest 4.x.
+	class MockIssuerClient {
+		authorizationUrl: any;
+		callback: any;
+		userinfo: any;
+		issuer: any;
+
+		constructor() {
+			this.authorizationUrl = mockAuthorizationUrl;
+			this.callback = mockCallback;
+			this.userinfo = vi.fn().mockResolvedValue({});
+			this.issuer = { metadata: {} };
+		}
+	}
+
+	return {
+		Issuer: {
+			discover: vi.fn().mockResolvedValue({
+				metadata: { response_types_supported: ['code'] },
+				Client: MockIssuerClient,
+			}),
+		},
+		generators: {
+			codeVerifier: vi.fn().mockReturnValue('mock-code-verifier'),
+			codeChallenge: vi.fn().mockReturnValue('mock-code-challenge'),
+		},
+		errors: {
+			OPError: class OPError extends Error {},
+			RPError: class RPError extends Error {},
+		},
+	};
+});
+
+import { OpenIDAuthDriver } from './openid.js';
+
+const testSchema = {
+	collections: {
+		directus_users: {
+			collection: 'directus_users',
+			primary: 'id',
+			singleton: false,
+			sortField: null,
+			note: null,
+			accountability: null,
+			fields: {
+				id: {
+					field: 'id',
+					defaultValue: null,
+					nullable: false,
+					generated: true,
+					type: 'integer',
+					dbType: 'integer',
+					precision: null,
+					scale: null,
+					special: [],
+					note: null,
+					validation: null,
+					alias: false,
+				},
+			},
+		},
+	},
+	relations: [],
+} as SchemaOverview;
+
+describe('OpenIDAuthDriver', () => {
+	let db: MockedFunction<Knex>;
+	let service: OpenIDAuthDriver;
+
+	beforeAll(async () => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+	});
+
+	beforeEach(() => {
+		service = new OpenIDAuthDriver(
+			{ knex: db, schema: testSchema },
+			{
+				issuerUrl: 'https://provider.example.com',
+				clientId: 'test-client-id',
+				clientSecret: 'test-client-secret',
+				provider: 'test-provider',
+				scope: 'openid profile email',
+			}
+		);
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('generateAuthUrl', () => {
+		it('uses clean redirect_uri without appended query params', async () => {
+			await service.generateAuthUrl('test-verifier', false);
+
+			expect(mockAuthorizationUrl).toHaveBeenCalledWith(
+				expect.objectContaining({
+					redirect_uri: 'http://localhost:8055/auth/login/test-provider/callback',
+				})
+			);
+		});
+
+		it('does not append redirect to redirect_uri when additionalParams contains redirect', async () => {
+			await service.generateAuthUrl('test-verifier', false, {
+				redirect: 'http://localhost:8055/admin/content' as any,
+			});
+
+			const calledWith = mockAuthorizationUrl.mock.calls[0]![0] as Record<string, unknown>;
+
+			expect(calledWith['redirect_uri']).toBe('http://localhost:8055/auth/login/test-provider/callback');
+			expect(calledWith['redirect_uri']).not.toContain('?redirect=');
+			expect(calledWith).not.toHaveProperty('redirect');
+		});
+
+		it('passes other additionalParams through while stripping redirect', async () => {
+			await service.generateAuthUrl('test-verifier', false, {
+				redirect: 'http://localhost:8055/admin/content' as any,
+				login_hint: 'user@example.com',
+			});
+
+			const calledWith = mockAuthorizationUrl.mock.calls[0]![0] as Record<string, unknown>;
+
+			expect(calledWith['login_hint']).toBe('user@example.com');
+			expect(calledWith).not.toHaveProperty('redirect');
+		});
+
+		it('works when additionalParams is undefined', async () => {
+			await service.generateAuthUrl('test-verifier', false, undefined);
+
+			expect(mockAuthorizationUrl).toHaveBeenCalledWith(
+				expect.objectContaining({
+					redirect_uri: 'http://localhost:8055/auth/login/test-provider/callback',
+				})
+			);
+		});
+
+		it('includes prompt=consent when prompt flag is true', async () => {
+			await service.generateAuthUrl('test-verifier', true);
+
+			expect(mockAuthorizationUrl).toHaveBeenCalledWith(
+				expect.objectContaining({
+					prompt: 'consent',
+				})
+			);
+		});
+	});
+
+	describe('getTokenSetAndUserInfo', () => {
+		it('passes clean redirect_uri to client.callback', async () => {
+			await service.getTokenSetAndUserInfo({
+				code: 'auth-code',
+				codeVerifier: 'test-verifier',
+				state: 'test-state',
+			});
+
+			expect(mockCallback).toHaveBeenCalledWith(
+				'http://localhost:8055/auth/login/test-provider/callback',
+				expect.objectContaining({ code: 'auth-code' }),
+				expect.any(Object)
+			);
+		});
+
+		it('does not modify redirect_uri when payload contains redirect', async () => {
+			await service.getTokenSetAndUserInfo({
+				code: 'auth-code',
+				codeVerifier: 'test-verifier',
+				state: 'test-state',
+				redirect: 'http://localhost:8055/admin/content',
+			});
+
+			const calledRedirectUri = mockCallback.mock.calls[0]![0];
+
+			expect(calledRedirectUri).toBe('http://localhost:8055/auth/login/test-provider/callback');
+			expect(calledRedirectUri).not.toContain('?redirect=');
+		});
+
+		it('returns tokenSet, userInfo, and userPayload', async () => {
+			const [tokenSet, userInfo, userPayload] = await service.getTokenSetAndUserInfo({
+				code: 'auth-code',
+				codeVerifier: 'test-verifier',
+				state: 'test-state',
+			});
+
+			expect(tokenSet).toHaveProperty('access_token', 'mock-access-token');
+			expect(userInfo).toHaveProperty('email', 'user@example.com');
+			expect(userPayload).toMatchObject({
+				provider: 'test-provider',
+				email: 'user@example.com',
+				external_identifier: 'user-123',
+			});
+		});
+
+		it('includes refresh_token in auth_data when provider returns one', async () => {
+			const [, , userPayload] = await service.getTokenSetAndUserInfo({
+				code: 'auth-code',
+				codeVerifier: 'test-verifier',
+				state: 'test-state',
+			});
+
+			expect(userPayload.auth_data).toBe(JSON.stringify({ refreshToken: 'mock-refresh-token' }));
+		});
+
+		it('returns falsy auth_data when provider does not return a refresh_token', async () => {
+			mockCallback.mockResolvedValueOnce({
+				access_token: 'mock-access-token',
+				refresh_token: undefined,
+				claims: () => ({
+					sub: 'user-123',
+					email: 'user@example.com',
+					given_name: 'Test',
+					family_name: 'User',
+				}),
+			});
+
+			const [, , userPayload] = await service.getTokenSetAndUserInfo({
+				code: 'auth-code',
+				codeVerifier: 'test-verifier',
+				state: 'test-state',
+			});
+
+			// When no refresh_token, auth_data should be falsy.
+			// The baseoauth.ts ?? null fix handles coercing this to null for Knex.
+			expect(userPayload.auth_data).toBeFalsy();
+		});
+	});
+});

--- a/api/src/auth/drivers/openid.ts
+++ b/api/src/auth/drivers/openid.ts
@@ -118,16 +118,11 @@ export class OpenIDAuthDriver extends BaseOAuthDriver {
 			const codeChallenge = generators.codeChallenge(codeVerifier);
 			const paramsConfig = typeof this.config['params'] === 'object' ? this.config['params'] : {};
 
-			const redirectAfterLogin = additionalParams?.['redirect'];
+			// Remove redirect from params passed to OAuth provider.
+			// The redirect target is stored in the JWT cookie (set by the router handler),
+			// NOT in the redirect_uri. Appending it to redirect_uri breaks strict OAuth
+			// providers like Azure AD that enforce exact redirect_uri matching (AADSTS50011).
 			delete additionalParams?.['redirect'];
-
-			let finalRedirectUri = this.redirectUrl;
-
-			if (redirectAfterLogin) {
-				const redirectUriWithParams = new URL(this.redirectUrl);
-				redirectUriWithParams.searchParams.set('redirect', redirectAfterLogin as string);
-				finalRedirectUri = redirectUriWithParams.toString();
-			}
 
 			return client.authorizationUrl({
 				scope: this.config['scope'] ?? 'openid profile email',
@@ -139,7 +134,7 @@ export class OpenIDAuthDriver extends BaseOAuthDriver {
 				// Some providers require state even with PKCE
 				state: codeChallenge,
 				nonce: codeChallenge,
-				redirect_uri: finalRedirectUri,
+				redirect_uri: this.redirectUrl,
 				...additionalParams,
 			});
 		} catch (e) {
@@ -157,16 +152,8 @@ export class OpenIDAuthDriver extends BaseOAuthDriver {
 			const client = await this.client;
 			const codeChallenge = generators.codeChallenge(payload['codeVerifier']);
 
-			let finalRedirectUri = this.redirectUrl;
-
-			if (payload['redirect']) {
-				const redirectUriWithParams = new URL(this.redirectUrl);
-				redirectUriWithParams.searchParams.set('redirect', payload['redirect'] as string);
-				finalRedirectUri = redirectUriWithParams.toString();
-			}
-
 			tokenSet = await client.callback(
-				finalRedirectUri,
+				this.redirectUrl,
 				{ code: payload['code'], state: payload['state'], iss: payload['iss'] },
 				{ code_verifier: payload['codeVerifier'], state: codeChallenge, nonce: codeChallenge }
 			);


### PR DESCRIPTION
## Description

PR #163 introduced appending `?redirect=<url>` to the `redirect_uri` sent to the OAuth provider during OpenID login. This breaks **Azure AD (Microsoft Entra ID)** and any OAuth provider that enforces exact `redirect_uri` matching, causing [AADSTS50011](https://learn.microsoft.com/en-us/troubleshoot/entra/entra-id/app-integration/error-code-aadsts50011-redirect-uri-mismatch).

Microsoft's [official documentation](https://learn.microsoft.com/en-us/entra/identity-platform/reply-url) states that redirect URIs are subject to **exact string matching**, including query parameters. Since the appended `redirect` value changes per request (e.g. `/admin/login?continue=` vs `/admin/login?reason=SESSION_EXPIRED&continue=`), it can never match a statically registered redirect URI.

### What this PR changes

In `openid.ts`, the `redirect` parameter is no longer appended to the `redirect_uri` in both `generateAuthUrl()` and `getTokenSetAndUserInfo()`. The `redirect_uri` is now always the static callback URL (`{PUBLIC_URL}/auth/login/{provider}/callback`).

This is safe because the **redirect target is already stored in the JWT cookie** (set by the router handler at line 229), which survives the OAuth round-trip. This is the same approach used by the original Directus 9.x.

### What is NOT changed

- **State-based cookie naming** (`openid.<provider>.<state>`) from PR #163 is kept — it's a good improvement for multi-tab login support and doesn't affect OAuth providers.
- **Error redirect handling** from PR #163 is kept — redirecting to login page on verification error is useful.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fixes Azure AD login broken by PR #163. Related to #127 (same area of code).

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Network

- [x] Changes to network configurations have been reviewed
- [x] Any newly exposed public endpoints or data have gone through security review

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] reviewers assigned
- [ ] Pull request linked to task tracker where applicable
