### PR TITLE
fix: ambiguous column name on joinLeft

### DIFF
--- a/.changeset/green-boxes-live.md
+++ b/.changeset/green-boxes-live.md
@@ -1,0 +1,5 @@
+---
+'@wbce-d9/api': patch
+---
+
+qualify the `collection` scope column in many-to-any (a2o/o2a) filter and sort JOINs

--- a/api/src/utils/apply-query.ts
+++ b/api/src/utils/apply-query.ts
@@ -179,7 +179,7 @@ function addJoin({ path, collection, aliasMap, rootQuery, schema, relations, kne
 
 				rootQuery.leftJoin({ [alias]: pathScope }, (joinClause) => {
 					joinClause
-						.onVal(relation.meta!.one_collection_field!, '=', pathScope)
+						.onVal(`${aliasedParentCollection}.${relation.meta!.one_collection_field!}`, '=', pathScope)
 						.andOn(
 							`${aliasedParentCollection}.${relation.field}`,
 							'=',
@@ -194,7 +194,7 @@ function addJoin({ path, collection, aliasMap, rootQuery, schema, relations, kne
 			} else if (relationType === 'o2a') {
 				rootQuery.leftJoin({ [alias]: relation.collection }, (joinClause) => {
 					joinClause
-						.onVal(relation.meta!.one_collection_field!, '=', parentCollection)
+						.onVal(`${alias}.${relation.meta!.one_collection_field!}`, '=', parentCollection)
 						.andOn(
 							`${alias}.${relation.field}`,
 							'=',


### PR DESCRIPTION
## Change description

In many-to-any relations (a2o / o2a), the `collection` scope column added to
`leftJoin` clauses was referenced without a table/alias qualifier. As soon
as a query touches two such relations, `collection` becomes ambiguous and the
database rejects the query.

This PR qualifies that column with the owning table alias so the JOIN is
unambiguous:

- **a2o**: `collection` → `<parentCollection>.collection`
- **o2a**: `collection` → `<alias>.collection`

`api/src/utils/apply-query.ts` — `addJoin()`.

## Type of change

- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

When a collection has **two many-to-any relationships** and a filter (or sort)
is applied across both, the generated SQL fails with `column reference
"collection" is ambiguous`.

### Reproduction

Filtering on two m2a/o2a relations of the same collection triggers:

```json
{ "errors": [ { "message": "... left join \"t2\" as \"vmrux\" on \"collection\" = $1 ... left join \"t3\" as \"rsiha\" on \"collection\" = $2 ... - column reference \"collection\" is ambiguous", "extensions": { "code": "INTERNAL_SERVER_ERROR" } } ] }
```

### Before (ambiguous `collection`)

```sql
LEFT JOIN t2 AS vmrux
    ON collection = $1
   AND qlwxc.item = CAST(vmrux.id AS CHAR(255))

LEFT JOIN t3 AS rsiha
    ON collection = $2                       -- which "collection"? ❌
   AND gnbxu.item = CAST(rsiha.id AS CHAR(255))
```

### After (qualified)

```sql
LEFT JOIN t2 AS vmrux
    ON t.collection = $1
   AND qlwxc.item = CAST(vmrux.id AS CHAR(255))

LEFT JOIN t3 AS rsiha
    ON t.collection = $2                      -- unambiguous ✅
   AND gnbxu.item = CAST(rsiha.id AS CHAR(255))
```

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [X] Automated tests covering modified code pass

### Security

- [X] Security impact of change has been considered
- [X] Code follows company security practices and guidelines

### Network

- [X] Changes to network configurations have been reviewed
- [X] Any newly exposed public endpoints or data have gone through security review

### Code review

- [X] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as
      necessary
- [X] reviewers assigned
- [X] Pull request linked to task tracker where applicable